### PR TITLE
[HOTFIX] Commented out 'yo we in there'

### DIFF
--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -79,7 +79,7 @@ async def on_ready():
                 )
             )
 
-            await channel.send('yo we in there')
+#            await channel.send('yo we in there')
 
 
 #@bot.event

--- a/discord_quote/discord_quote/discord_quote.py
+++ b/discord_quote/discord_quote/discord_quote.py
@@ -118,6 +118,8 @@ async def me(ctx, *text : str):
 
 @bot.command(aliases=['q'])
 async def quote(ctx, *, request:str):
+    """Quote an existing message. Make sure you have Discord's developer mode turned on."""
+
     log.info(log_msg(['received_request',
                       'quote',
                       ctx.message.channel.name,


### PR DESCRIPTION
# Issue

Docker seems to be restarting container much more frequently then before, the 'yo we in there' message is becoming disruptive. It is also not affecting functionality, so we will comment it out. We leave the on_ready message commented because it is useful for dev versions to know when restarts have happened.

